### PR TITLE
Fix runtime filter for quotes started tab

### DIFF
--- a/src/components/SidebarItems/QuotesBinds.js
+++ b/src/components/SidebarItems/QuotesBinds.js
@@ -22,7 +22,6 @@ const QuotesBinds = ({ selectedItem, selectedTabIndex, handleTabChange, days, se
             <TabHandler
               tab={tab}
               selectedItem={selectedItem}
-              selectedTabIndex={selectedTabIndex}
               days={days}
               setDays={setDays}
               columnName={columnName}
@@ -30,16 +29,6 @@ const QuotesBinds = ({ selectedItem, selectedTabIndex, handleTabChange, days, se
           </Tab>
         ))}
       </Tabs>
-
-      {selectedItem.tabs[selectedTabIndex].vizIds.map((vizId, idx) => (
-        <ThoughtSpotEmbed
-          key={vizId + idx}
-          days={days}
-          columnName={columnName}
-          liveboardId={selectedItem.liveboardId}
-          vizId={vizId}
-        />
-      ))}
     </>
   );
 };

--- a/src/components/TabHandler.js
+++ b/src/components/TabHandler.js
@@ -1,35 +1,35 @@
 import React from "react";
 import ThoughtSpotEmbed from "./ThoughtSpotEmbed";
 
+const TabHandler = ({ tab, selectedItem, days, setDays, columnName }) => {
+  const filterDays = tab.isDatepicker ? days : null;
+  const filterColumn = tab.isDatepicker ? columnName : null;
 
-const TabHandler = ({tab,selectedItem,selectedTabIndex,days, setDays, columnName}) => {
-  
+  return (
+    <>
+      {tab.isDatepicker && (
+        <div className="date-picker">
+          <label htmlFor="dateInput">Select Date From:</label>
+          <input
+            id="dateInput"
+            type="date"
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+          />
+        </div>
+      )}
 
-  return(
-                    <>
-                      {tab.isDatepicker ? (
-                        <div className="date-picker">
-                          <label htmlFor="dateInput">Select Date From:</label>
-                          <input
-                            id="dateInput"
-                            type="date"
-                            value={days}
-                            onChange={(e) => setDays(e.target.value)}
-                          />
-                        </div>
-                      ) : null}
+      {tab.vizIds?.map((vizId, idx) => (
+        <ThoughtSpotEmbed
+          key={vizId + idx}
+          days={filterDays}
+          columnName={filterColumn}
+          liveboardId={selectedItem.liveboardId}
+          vizId={vizId}
+        />
+      ))}
+    </>
+  );
+};
 
-                      {selectedItem?.tabs[selectedTabIndex]?.vizIds?.map(
-                        (vizId, idx) => (
-                          <ThoughtSpotEmbed
-                            key={vizId + idx}
-                            days={days}
-                            columnName={'Click Date Time AZ'}
-                            liveboardId={selectedItem.liveboardId}
-                            vizId={vizId}
-                          />
-                        )
-                      )}
-                    </>
-  );}
-  export default TabHandler;
+export default TabHandler;


### PR DESCRIPTION
## Summary
- avoid passing date filters when not needed
- simplify tab handler logic to use tab data

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519a5b005483239152233271c3c57b