### PR TITLE
Add header navbar and style dropdowns

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -103,3 +103,25 @@ input[type="date"],
   border-radius: 4px;
   font-size: 14px;
 }
+
+.header-navbar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  background-color: #1e1e2f;
+  padding: 10px;
+}
+
+.nav-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 16px;
+  color: white;
+}
+
+.nav-item.active {
+  background-color: #4ade80;
+  color: #1e1e2f;
+  font-weight: 600;
+}

--- a/src/components/HeaderNav.js
+++ b/src/components/HeaderNav.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+const HeaderNav = ({ activeTab, setActiveTab }) => {
+  const navItems = [
+    { key: "gps", label: "GPS" },
+  ];
+
+  return (
+    <div className="header-navbar">
+      {navItems.map((item) => (
+        <div
+          key={item.key}
+          className={`nav-item ${activeTab === item.key ? "active" : ""}`}
+          onClick={() => setActiveTab(item.key)}
+        >
+          {item.label}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default HeaderNav;

--- a/src/components/Maincontent.js
+++ b/src/components/Maincontent.js
@@ -1,26 +1,21 @@
 import React, { useState } from "react";
 import Stellantis from "./SidebarItems/Stellantis";
-import Tab from "react-bootstrap/Tab";
-import Tabs from "react-bootstrap/Tabs";
+import HeaderNav from "./HeaderNav";
 
 const Maincontent = ({ selectedMenu, menuItems }) => {
   const [policyId, setPolicyId] = useState("");
   const [deviceId, setDeviceId] = useState("");
   const [tripId, setTripId] = useState("");
+  const [activeTab, setActiveTab] = useState("gps");
 
   const selectedItem = menuItems.find((item) => item.key === selectedMenu);
 
   return (
     <div>
-    {selectedMenu === "Stellantis"?(
-      <Tabs
-        defaultActiveKey="gps"
-        id="fill-tab-example"
-        className="mb-3"
-        fill
-      >
-        <Tab eventKey="gps" title="GPS">
-          {selectedMenu === "Stellantis" && (
+      {selectedMenu === "Stellantis" && (
+        <>
+          <HeaderNav activeTab={activeTab} setActiveTab={setActiveTab} />
+          {activeTab === "gps" && (
             <Stellantis
               selectedItem={selectedItem}
               policyId={policyId}
@@ -31,13 +26,8 @@ const Maincontent = ({ selectedMenu, menuItems }) => {
               setTripId={setTripId}
             />
           )}
-        </Tab>
-      </Tabs>
-      ):(
-      <>
-      </>
-      )
-    }
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/SidebarItems/Stellantis.js
+++ b/src/components/SidebarItems/Stellantis.js
@@ -18,6 +18,26 @@ const Stellantis = ({
   const [tripOptions, setTripOptions] = useState([]);
   const [deviceOptions, setDeviceOptions] = useState([]);
 
+  const selectStyles = {
+    control: (provided) => ({
+      ...provided,
+      minHeight: "30px",
+      fontSize: "12px",
+    }),
+    option: (provided) => ({
+      ...provided,
+      fontSize: "12px",
+    }),
+    multiValue: (provided) => ({
+      ...provided,
+      fontSize: "12px",
+    }),
+    multiValueLabel: (provided) => ({
+      ...provided,
+      fontSize: "12px",
+    }),
+  };
+
   const [loadingPolicies, setLoadingPolicies] = useState(true);
   const [loadingTrips, setLoadingTrips] = useState(true);
   const [loadingDevices, setLoadingDevices] = useState(true);
@@ -76,6 +96,7 @@ const Stellantis = ({
               onChange={(selected) => setPolicyId(selected?.value || "")}
               placeholder="Select a Policy ID"
               isClearable
+              styles={selectStyles}
             />
           )}
         </div>
@@ -91,6 +112,7 @@ const Stellantis = ({
               onChange={(selected) => setDeviceId(selected?.value || "")}
               placeholder="Select a Device ID"
               isClearable
+              styles={selectStyles}
             />
           )}
         </div>
@@ -106,6 +128,7 @@ const Stellantis = ({
               onChange={(selected) => setTripId(selected?.value || "")}
               placeholder="Select a Trip ID"
               isClearable
+              styles={selectStyles}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- implement `HeaderNav` component with GPS default option
- use `HeaderNav` inside `Maincontent`
- style new navbar in `App.css`
- refine dropdown font sizes via `selectStyles`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1c94cd508323b75536906d484176