### PR TITLE
Fix partner filter logic

### DIFF
--- a/src/components/NovoBiz/novobiz.js
+++ b/src/components/NovoBiz/novobiz.js
@@ -120,7 +120,7 @@ const Novobiz = () => {
                 selectedPartners.includes(opt.value)
               )}
               onChange={(selected) =>
-                setSelectedPartners(selected.map((opt) => opt.value))
+                setSelectedPartners(selected ? selected.map((opt) => opt.value) : [])
               }
               placeholder="Select Partner(s)"
               styles={selectStyles}

--- a/src/components/NovoBiz/novobizcommon.js
+++ b/src/components/NovoBiz/novobizcommon.js
@@ -20,13 +20,13 @@ const NovobizCommon = ({ liveboardId, tabID, selectedDate, partners }) => {
       });
     }
 
-    if (partners) {
-    runtimeFilters.push({
-      columnName: 'Partner',
-      operator: RuntimeFilterOp.IN,
-      values: partners,
-    });
-  }
+    if (partners && partners.length > 0) {
+      runtimeFilters.push({
+        columnName: 'Partner',
+        operator: RuntimeFilterOp.IN,
+        values: partners,
+      });
+    }
 
     const liveboard = new LiveboardEmbed(ref.current, {
       liveboardId,


### PR DESCRIPTION
## Summary
- prevent empty partner filter from being applied
- handle clearing partner dropdown correctly

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbfbd21408323b6f9df61fdd7ecda